### PR TITLE
chore: match jpeg files as image

### DIFF
--- a/themes/2023/theme-dark.json
+++ b/themes/2023/theme-dark.json
@@ -226,6 +226,7 @@
     "png": "file_image",
     "webp": "file_image",
     "jpg": "file_image",
+    "jpeg": "file_image",
     "gif": "file_image",
     "ico": "file_image",
     "svg": "file_image",

--- a/themes/2023/theme-light.json
+++ b/themes/2023/theme-light.json
@@ -226,6 +226,7 @@
     "png": "file_image",
     "webp": "file_image",
     "jpg": "file_image",
+    "jpeg": "file_image",
     "gif": "file_image",
     "ico": "file_image",
     "svg": "file_image",


### PR DESCRIPTION
From the web:

> JPG and JPEG are two equivalent file extensions that both refer to the same digital image format, so there are actually no differences between the JPG and JPEG formats. The only difference is the number of characters used.

> JPG exists because the earlier versions of Windows operating systems had a maximum 3-letter limit when it came to file names. UNIX-like operating systems like Mac or Linux never had this limit.

Also, JetBrains editors already match jpeg files as image.