### PR TITLE
feat: add icons for yarn pnpm and eslint

### DIFF
--- a/themes/2023/theme-dark.json
+++ b/themes/2023/theme-dark.json
@@ -210,6 +210,7 @@
     ".eslintrc.cjs": "file_eslint",
     ".eslintrc.js": "file_eslint",
     ".eslintrc.ts": "file_eslint",
+    ".eslintrc.json": "file_eslint",
     ".eslintrc.yml": "file_eslint",
     ".eslintrc.yaml": "file_eslint",
     ".eslintignore": "file_eslint"

--- a/themes/2023/theme-dark.json
+++ b/themes/2023/theme-dark.json
@@ -176,6 +176,7 @@
     ".gitignore": "file_gitignore",
     ".gitattributes": "file_gitignore",
     ".editorconfig": "file_editorconfig",
+    ".yarnrc": "file_yarn",
     "yarn.lock": "file_yarn",
     "README": "file_markdown",
     ".dockerignore": "file_ignored",
@@ -194,6 +195,7 @@
     "Cargo.lock": "file_cargolock",
     "CMakeLists.txt": "file_cmake",
     "pnpm-lock.yaml": "file_pnpm",
+    "pnpm-workspace.yaml": "file_pnpm",
     "tailwind.config.js": "file_tailwind",
     "tailwind.config.cjs": "file_tailwind",
     "tailwind.config.ts": "file_tailwind",
@@ -208,6 +210,8 @@
     ".eslintrc.cjs": "file_eslint",
     ".eslintrc.js": "file_eslint",
     ".eslintrc.ts": "file_eslint",
+    ".eslintrc.yml": "file_eslint",
+    ".eslintrc.yaml": "file_eslint",
     ".eslintignore": "file_eslint"
   },
   "fileExtensions": {

--- a/themes/2023/theme-light.json
+++ b/themes/2023/theme-light.json
@@ -210,6 +210,7 @@
     ".eslintrc.cjs": "file_eslint",
     ".eslintrc.js": "file_eslint",
     ".eslintrc.ts": "file_eslint",
+    ".eslintrc.json": "file_eslint",
     ".eslintrc.yml": "file_eslint",
     ".eslintrc.yaml": "file_eslint",
     ".eslintignore": "file_eslint"

--- a/themes/2023/theme-light.json
+++ b/themes/2023/theme-light.json
@@ -176,6 +176,7 @@
     ".gitignore": "file_gitignore",
     ".gitattributes": "file_gitignore",
     ".editorconfig": "file_editorconfig",
+    ".yarnrc": "file_yarn",
     "yarn.lock": "file_yarn",
     "README": "file_markdown",
     ".dockerignore": "file_ignored",
@@ -194,6 +195,7 @@
     "Cargo.lock": "file_cargolock",
     "CMakeLists.txt": "file_cmake",
     "pnpm-lock.yaml": "file_pnpm",
+    "pnpm-workspace.yaml": "file_pnpm",
     "tailwind.config.js": "file_tailwind",
     "tailwind.config.cjs": "file_tailwind",
     "tailwind.config.ts": "file_tailwind",
@@ -208,6 +210,8 @@
     ".eslintrc.cjs": "file_eslint",
     ".eslintrc.js": "file_eslint",
     ".eslintrc.ts": "file_eslint",
+    ".eslintrc.yml": "file_eslint",
+    ".eslintrc.yaml": "file_eslint",
     ".eslintignore": "file_eslint"
   },
   "fileExtensions": {


### PR DESCRIPTION
__[eslint docs](https://eslint.org/docs/latest/use/configure/configuration-files)__  
`.eslintrc.yaml` `.eslintrc.yml` `.eslintrc.json` are also valid eslint configuration files.

__[yarn docs](https://classic.yarnpkg.com/lang/en/docs/yarnrc/)__  
`.yarnrc` files allow you to configure additional Yarn features.

__[pnpm docs](https://pnpm.io/workspaces)__  
A workspace must have a [`pnpm-workspace.yaml`](https://pnpm.io/pnpm-workspace_yaml) file in its root. A workspace also may have an [`.npmrc`](https://pnpm.io/npmrc) in its root.

I couldn't find a perfect icon for `.npmrc` so I didn't add it. Maybe ![icon](https://raw.githubusercontent.com/cadamsdev/vscode-jetbrains-icon-theme/main/themes/2023/icons/editorConfig.svg) [`editorConfig.svg`](https://github.com/cadamsdev/vscode-jetbrains-icon-theme/blob/main/themes/2023/icons/editorConfig.svg)?