### PR TITLE
fix: dark ruby icon path

### DIFF
--- a/themes/2023/theme-dark.json
+++ b/themes/2023/theme-dark.json
@@ -31,7 +31,7 @@
       "iconPath": "./icons/react_dark.svg"
     },
     "file_ruby": {
-      "iconPath": "./icons/dark_ruby.svg"
+      "iconPath": "./icons/ruby_dark.svg"
     },
     "file_rake": {
       "iconPath": "./icons/rakeTask_dark.svg"


### PR DESCRIPTION
Hello, this fixes #105 - dark theme ruby icon path.