### PR TITLE
feat(docker): Support more Dockerfile filename variants

### DIFF
--- a/assets/2023/theme-dark.json
+++ b/assets/2023/theme-dark.json
@@ -209,8 +209,10 @@
     "README": "file_markdown",
     ".dockerignore": "file_ignored",
     "Dockerfile": "file_docker",
+    "Dockerfile.dev": "file_docker",
     "Dockerfile.test": "file_docker",
     "Dockerfile.staging": "file_docker",
+    "Dockerfile.prod": "file_docker",
     "Dockerfile.production": "file_docker",
     "Gemfile": "file_gemfile",
     "Gemfile.lock": "file_gemfile",
@@ -323,11 +325,12 @@
     "cs": "file_cs",
     "cshtml": "file_cshtml",
     "csproj": "file_csproj",
-    "ex" : "file_elixir",
-    "exs" : "file_elixir",
-    "eex" : "file_embedded_elixir",
-    "heex" : "file_embedded_elixir",
-    "leex" : "file_embedded_elixir",
-    "beam" : "file_beam"
+    "ex": "file_elixir",
+    "exs": "file_elixir",
+    "eex": "file_embedded_elixir",
+    "heex": "file_embedded_elixir",
+    "leex": "file_embedded_elixir",
+    "beam": "file_beam",
+    "dockerfile": "file_docker"
   }
 }

--- a/assets/2023/theme-light.json
+++ b/assets/2023/theme-light.json
@@ -209,8 +209,10 @@
     "README": "file_markdown",
     ".dockerignore": "file_ignored",
     "Dockerfile": "file_docker",
+    "Dockerfile.dev": "file_docker",
     "Dockerfile.test": "file_docker",
     "Dockerfile.staging": "file_docker",
+    "Dockerfile.prod": "file_docker",
     "Dockerfile.production": "file_docker",
     "Gemfile": "file_gemfile",
     "Gemfile.lock": "file_gemfile",
@@ -323,11 +325,12 @@
     "cs": "file_cs",
     "cshtml": "file_cshtml",
     "csproj": "file_csproj",
-    "ex" : "file_elixir",
-    "exs" : "file_elixir",
-    "eex" : "file_embedded_elixir",
-    "heex" : "file_embedded_elixir",
-    "leex" : "file_embedded_elixir",
-    "beam" : "file_beam"
+    "ex": "file_elixir",
+    "exs": "file_elixir",
+    "eex": "file_embedded_elixir",
+    "heex": "file_embedded_elixir",
+    "leex": "file_embedded_elixir",
+    "beam": "file_beam",
+    "dockerfile": "file_docker"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "email": "me@chadalen.com",
     "url": "https://cadamsdev.com"
   },
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "prebuild": "tsx ./scripts/build/build.ts",
     "build": "vsce package"


### PR DESCRIPTION
This adds Dockerfile support for `*.dockerfile`, `Dockerfile.dev`, and `Dockerfile.prod`. [This GitHub comment](https://github.com/microsoft/vscode-docker/issues/1907#issuecomment-618477074) mentions that these are the top three alternative Dockerfile filename variants based on VS Code's telemetry data.

I wasn't sure where to add the "dockerfile" entry in the "fileExtensions" section, so I just added it to the end. Let me know if I should add it somewhere else. Also, my editor auto-fixed the formatting of the items above the new "dockerfile" entry (removing the extra spaces to the left of the colons), but I can undo those fixes if you would prefer that I don't include those changes in this PR.