### PR TITLE
feat: add .pyi and .pyc icons

### DIFF
--- a/assets/2023/theme-dark.json
+++ b/assets/2023/theme-dark.json
@@ -356,6 +356,8 @@
     "tar": "file_archive",
     "toml": "file_toml",
     "py": "file_python",
+    "pyi": "file_python",
+    "pyc": "file_python",
     "tf": "file_terraform",
     "go": "file_go",
     "http": "file_http",

--- a/assets/2023/theme-light.json
+++ b/assets/2023/theme-light.json
@@ -356,6 +356,8 @@
     "tar": "file_archive",
     "toml": "file_toml",
     "py": "file_python",
+    "pyi": "file_python",
+    "pyc": "file_python",
     "tf": "file_terraform",
     "go": "file_go",
     "http": "file_http",


### PR DESCRIPTION
Add Python icons for the extensions .pyi and .pyc in both themes.