### PR TITLE
feat: add support for razor files

### DIFF
--- a/assets/2023/theme-dark.json
+++ b/assets/2023/theme-dark.json
@@ -519,6 +519,7 @@
     "ora": "file_db",
     "lock": "file_lock",
     "ino": "file_ino",
-    "jinja": "file_html"
+    "jinja": "file_html",
+    "razor": "file_cshtml"
   }
 }

--- a/assets/2023/theme-light.json
+++ b/assets/2023/theme-light.json
@@ -519,6 +519,7 @@
     "ora": "file_db",
     "lock": "file_lock",
     "ino": "file_ino",
-    "jinja": "file_html"
+    "jinja": "file_html",
+    "razor": "file_cshtml"
   }
 }


### PR DESCRIPTION
This PR simply extends support and reuses the `cshtml` icon for `.razor` file extension.
V1 has no corresponding file to use. 
![image](https://github.com/user-attachments/assets/c8d62e13-8586-425b-ad11-9f86f278e98d)
